### PR TITLE
Roundtrip data: client-> server -> subbed clients

### DIFF
--- a/app/assets/javascripts/channels/room.coffee
+++ b/app/assets/javascripts/channels/room.coffee
@@ -6,7 +6,13 @@ App.room = App.cable.subscriptions.create "RoomChannel",
     # Called when the subscription has been terminated by the server
 
   received: (data) ->
-    # Called when there's incoming data on the websocket for this channel
+    alert(data['message'])
 
-  speak: ->
-    @perform 'speak'
+  speak: (message) ->
+    @perform 'speak', message: message
+
+$(document).on 'keypress', '[data-behavior~=room_speaker]', (event) ->
+  if event.keyCode is 13 #return/enter = send
+    App.room.speak event.target.value
+    event.target.value = ''
+    event.preventDefault()

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,13 +1,14 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
 class RoomChannel < ApplicationCable::Channel
   def subscribed
-    # stream_from "some_channel"
+    stream_from "room_channel"
   end
 
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end
 
-  def speak
+  def speak(data)
+    ActionCable.server.broadcast "room_channel", message: data['message']
   end
 end


### PR DESCRIPTION
Client-side: 
- configured received data to be an alert
- set up listener as a keypress to received message to send to server

Server-side: 
- names the channel "room_channel"
- speak method to say what would be broadcasted an how.
