### PR TITLE
messages persistent in the database

### DIFF
--- a/app/assets/javascripts/channels/room.coffee
+++ b/app/assets/javascripts/channels/room.coffee
@@ -6,7 +6,7 @@ App.room = App.cable.subscriptions.create "RoomChannel",
     # Called when the subscription has been terminated by the server
 
   received: (data) ->
-    alert(data['message'])
+    $('#messages').append data['message']
 
   speak: (message) ->
     @perform 'speak', message: message

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -9,6 +9,6 @@ class RoomChannel < ApplicationCable::Channel
   end
 
   def speak(data)
-    ActionCable.server.broadcast "room_channel", message: data['message']
+    Message.create!(content: data["message"])
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,3 @@
 class Message < ApplicationRecord
+  after_create_commit { MessageBroadcastJob.perform_later self }
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,4 +1,5 @@
 <h1>Chat room</h1>
+
 <div id="messages" >
   <%= render @messages %>
 </div>


### PR DESCRIPTION
Messages captured in form are saved in the database and by using MessageBroadcastJob, rendered on client in the array of messages instead of the alerts. 
